### PR TITLE
Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
       - clang-4.0
       - llvm-4.0
       - llvm-4.0-dev
+      - libc++1
 install:
   - ./configure --with-llvm-config=llvm-config-4.0
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ addons:
       - llvm-toolchain-trusty-4.0
       - ubuntu-toolchain-r-test
     packages:
+      - clang-4.0
       - llvm-4.0
       - llvm-4.0-dev
-      - libstdc++-6-dev
-      - libc++-1
 install:
   - ./configure
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
       - llvm-4.0
       - llvm-4.0-dev
       - libc++1
+      - libc++abi1
 install:
   - ./configure --with-llvm-config=llvm-config-4.0
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+dist: trusty
+language: cpp
+compiler:
+  - clang
+  - gcc
+addons:
+  apt:
+    sources:
+      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main'
+    packages:
+      - llvm-4.0
+      - llvm-4.0-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ install:
   - ./configure
 script:
   - make
-  - make test
+  ### The test can't run correctly; there's a weird interaction between LLVM and Travis
+  #- make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 dist: trusty
 language: cpp
-compiler:
-  - clang
-  - gcc
+compiler: clang
 addons:
   apt:
     sources:
@@ -12,7 +10,7 @@ addons:
       - llvm-4.0
       - llvm-4.0-dev
       - libstdc++-6-dev
-      - libc++
+      - libc++-1
 install:
   - ./configure
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,11 @@ addons:
       - llvm-toolchain-trusty-4.0
       - ubuntu-toolchain-r-test
     packages:
-      - clang-4.0
-      - llvm-4.0
       - llvm-4.0-dev
       - libc++1
       - libc++abi1
 install:
-  - PATH=`echo /usr/local/clang-4.*/bin`:$PATH
-  - ./configure
+  - ./configure --with-llvm-config=llvm-config-4.0
 script:
   - make
   ### The test can't run correctly; there's a weird interaction between LLVM and Travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ compiler:
 addons:
   apt:
     sources:
-      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main'
+      - llvm-toolchain-trusty-4.0
     packages:
-      - llvm-4.0
-      - llvm-4.0-dev
-      - libc++1
-      - libc++abi-dev
+      - llvm-3.9
+      - llvm-3.9-dev
+      - libstdc++-6-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ addons:
       - llvm-4.0
       - llvm-4.0-dev
       - libc++1
+      - libc++abi-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
       - llvm-4.0
       - llvm-4.0-dev
 install:
-  - ./configure
+  - ./configure --with-llvm-config=llvm-config-4.0
 script:
   - make
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ addons:
     sources:
       - llvm-toolchain-trusty-4.0
     packages:
-      - llvm-3.9
-      - llvm-3.9-dev
+      - llvm-4.0
+      - llvm-4.0-dev
       - libstdc++-6-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
   apt:
     sources:
       - llvm-toolchain-trusty-4.0
+      - ubuntu-toolchain-r-test
     packages:
       - llvm-4.0
       - llvm-4.0-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ addons:
     packages:
       - llvm-4.0
       - llvm-4.0-dev
+      - libstdc++6

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ addons:
       - libc++1
       - libc++abi1
 install:
-  - ./configure --with-llvm-config=llvm-config-4.0
+  - PATH=`echo /usr/local/clang-4.*/bin`:$PATH
+  - ./configure
 script:
   - make
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,9 @@ addons:
       - llvm-4.0
       - llvm-4.0-dev
       - libstdc++-6-dev
+      - libc++
+install:
+  - ./configure
+script:
+  - make
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ addons:
     packages:
       - llvm-4.0
       - llvm-4.0-dev
-      - libstdc++6
+      - libc++1


### PR DESCRIPTION
This turns on automated building in Travis

Note that tests are disabled; there's a weird interaction between the C++ runtime used for LLVM and the runtime that Travis supports. Debugging it requires way more knowledge about getting this sort of thing working than I know how to deal with.