### PR TITLE
Support for LLVM 7.0

### DIFF
--- a/generic/intrinsics.cpp
+++ b/generic/intrinsics.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "llvmtcl.h"
+#include "version.h"
 #include <tcl.h>
 #include <llvm/IR/Intrinsics.h>
 #include <llvm-c/Core.h>
@@ -31,7 +32,11 @@
 
 static const char *const intrinsicNames[] = {
 #define GET_INTRINSIC_NAME_TABLE
+#ifdef API_7
+#include <llvm/IR/IntrinsicImpl.inc>
+#else // !API_7
 #include <llvm/IR/Intrinsics.gen>
+#endif // API_7
 #undef GET_INTRINSIC_NAME_TABLE
 };
 

--- a/generic/llvmtcl.cpp
+++ b/generic/llvmtcl.cpp
@@ -50,6 +50,9 @@
 #include <llvm-c/Transforms/Scalar.h>
 #include <llvm-c/Transforms/Vectorize.h>
 #include "llvmtcl.h"
+#ifdef API_7
+#include <llvm-c/Transforms/Utils.h>
+#endif // API_7
 
 /*
  * ------------------------------------------------------------------------

--- a/generic/module.cpp
+++ b/generic/module.cpp
@@ -168,7 +168,11 @@ CopyModuleFromModule(
     llvm::Module *srcmod;
     if (GetModuleFromObj(interp, objv[1], srcmod) != TCL_OK)
         return TCL_ERROR;
+#ifdef API_7
+    auto tgtmod = llvm::CloneModule(*srcmod);
+#else // !API_7
     auto tgtmod = llvm::CloneModule(srcmod);
+#endif // API_7
     if (objc > 2) {
 	std::string tgtid = Tcl_GetString(objv[2]);
 	tgtmod->setModuleIdentifier(tgtid);

--- a/generic/version.h
+++ b/generic/version.h
@@ -23,6 +23,10 @@
 #error This version of LLVM is no longer supported; upgrade to 4.0 or later
 #endif // LLVM_VERSION_MAJOR > 3
 
+#if LLVM_VERSION_MAJOR > 6
+#define API_7 1
+#endif // LLVM_VERSION_MAJOR > 4
+
 #if LLVM_VERSION_MAJOR > 5
 #define API_6 1
 #endif // LLVM_VERSION_MAJOR > 4

--- a/llvmtcl-gen.inp
+++ b/llvmtcl-gen.inp
@@ -445,7 +445,6 @@ void LLVMAddIPSCCPPass(LLVMPassManagerRef PM);
 void LLVMAddInternalizePass(LLVMPassManagerRef, unsigned AllButMain);
 void LLVMAddStripDeadPrototypesPass(LLVMPassManagerRef PM);
 void LLVMAddStripSymbolsPass(LLVMPassManagerRef PM);
-void LLVMAddBBVectorizePass(LLVMPassManagerRef);
 void LLVMAddLoopVectorizePass(LLVMPassManagerRef);
 
 std::string LLVMGetDataLayout(LLVMModuleRef M);


### PR DESCRIPTION
This adds support for LLVM 7.0. Only API change is removal of `LLVMAddBBVectorizePass`; the underlying code was removed in LLVM 7 and there's no replacement (probably because the associated functionality is always enabled as part of something else).